### PR TITLE
use thread-safe event invocation for the BaseLogFactory.NewLog event

### DIFF
--- a/SolidDna/AngelSix.SolidDna/Logging/BaseLogFactory.cs
+++ b/SolidDna/AngelSix.SolidDna/Logging/BaseLogFactory.cs
@@ -140,8 +140,7 @@ namespace AngelSix.SolidDna
             });
 
             // Inform listeners
-            if (NewLog != null)
-                NewLog(message, level);
+            NewLog?.Invoke(message, level);
         }
 
         #endregion


### PR DESCRIPTION
If another thread unsubscribes from this event between the null check and the invocation, a `NullReferenceException` will be thrown.

This cannot happen when using the C# 6 null-conditional operator as it captures the event into a temporary variable.