### PR TITLE
convert the SolidDna project's NuGet reference over to the new PackageReference format

### DIFF
--- a/SolidDna/AngelSix.SolidDna/AngelSix.SolidDna.csproj
+++ b/SolidDna/AngelSix.SolidDna/AngelSix.SolidDna.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -30,9 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Ninject, Version=3.3.1.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
-      <HintPath>..\..\Tutorials\06-Exporting\SolidDna.Exporting\packages\Ninject.3.3.1\lib\net45\Ninject.dll</HintPath>
-    </Reference>
+    <PackageReference Include="Ninject" Version="3.3.1" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="SolidWorks.Interop.sldworks, Version=24.3.0.57, Culture=neutral, PublicKeyToken=7c4797c3e4eeac03, processorArchitecture=MSIL">
@@ -297,9 +295,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Localization\Strings\Strings%28en-US%29.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SolidDna/AngelSix.SolidDna/packages.config
+++ b/SolidDna/AngelSix.SolidDna/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Ninject" version="3.3.1" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
This allows the Ninject package to work properly no matter which Tutorial is opened, and it also allows me to use this git repository as a git submodule without having to make any changes to your code.

But, this will only work on Visual Studio 2017.  Let me know if you still need to work in VS 2015, because there is a more involved way to accomplish this with a NuGet.Config file that would support VS 2015.