### PR TITLE
File and SolidWorksTaskpane has the same value 

### DIFF
--- a/SolidDna/AngelSix.SolidDna/Errors/SolidDnaErrorTypeCode.cs
+++ b/SolidDna/AngelSix.SolidDna/Errors/SolidDnaErrorTypeCode.cs
@@ -19,7 +19,7 @@ namespace AngelSix.SolidDna
         /// <summary>
         /// An error occured while working with a file on the file system
         /// </summary>
-        File = 10,
+        File = 2,
 
         /// <summary>
         /// An error occured trying to perform a SolidWorks API call on the Taskpane


### PR DESCRIPTION
File and SolidWorksTaskpane has the same value  in enum SolidDnaErrorTypeCode