### PR TITLE
hook up ActiveConfigChangePostNotify for parts

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Model.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Model.cs
@@ -163,6 +163,7 @@ namespace AngelSix.SolidDna
                     AsAssembly().ClearSelectionsNotify += UserSelectionPostNotify;
                     break;
                 case ModelType.Part:
+                    AsPart().ActiveConfigChangePostNotify += ActiveConfigChangePostNotify;
                     AsPart().DestroyNotify += FileDestroyedNotify;
                     AsPart().FileSavePostNotify += FileSaveNotify;
                     AsPart().UserSelectionPostNotify += UserSelectionPostNotify;
@@ -187,7 +188,7 @@ namespace AngelSix.SolidDna
         #region Model Event Methods
 
         /// <summary>
-        /// Called when an assembly has it's active configuration changed
+        /// Called when a part or assembly has its active configuration changed
         /// </summary>
         /// <returns></returns>
         protected int ActiveConfigChangePostNotify()


### PR DESCRIPTION
Assemblies were updating when the configuration was changed, but parts were not.

I just registered the event handler for parts in the same way that it was done for assemblies.