### PR TITLE
Closing last document: made task run for every closing doc

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -323,17 +323,18 @@ namespace AngelSix.SolidDna
             //
             //
 
-            // If we currently only have this one document open...
-            if (mBaseObject.GetDocumentCount() == 1)
-                Task.Run(async () =>
-                {
-                    // Wait for it to close
-                    await Task.Delay(200);
+            // Check for every file if it may have been the last one.
+            Task.Run(async () =>
+            {
+                // Wait for it to close
+                await Task.Delay(200);
 
-                    // Now if we have none open, reload information
-                    if (mBaseObject?.GetDocumentCount() == 0)
-                        ReloadActiveModelInformation();
-                });
+                // Now if we have none open, reload information
+                // ActiveDoc is quickly set to null after the last document is closed
+                // GetDocumentCount takes longer to go to zero for big assemblies, but it might be a more reliable indicator.
+                if (mBaseObject?.ActiveDoc == null || mBaseObject?.GetDocumentCount() == 0)
+                    ReloadActiveModelInformation();
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
As discussed [here](https://github.com/angelsix/solidworks-api/issues/15)

ReloadActiveModelInformation now runs after every model close, instead of only when a single part was still open. 

I did a few tests and didn't notice different behavior for 50, 100 or 200ms but I decided to leave it like that for now.