### PR TITLE
SmallIconList typo

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
@@ -365,7 +365,7 @@ namespace AngelSix.SolidDna
                 mBaseObject.MainIconList = icons.ToArray();
 
                 // Use the largest available image for small icons too
-                mBaseObject.SmallIconList = icons.Last();
+                mBaseObject.SmallIconList = icons.First();
             }
 
             #endregion


### PR DESCRIPTION
This was pulling in the large icon which caused the icons in Customize > Commands to not show correctly.