### PR TITLE
SmallIconList typo, message box improvement

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/MessageBox/SolidWorksMessageBoxResult.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/MessageBox/SolidWorksMessageBoxResult.cs
@@ -1,0 +1,43 @@
+﻿namespace AngelSix.SolidDna
+{
+    /// <summary>
+    /// The result for a SolidWorks message, of type <see cref="swMessageBoxResult_e"/>
+    /// </summary>
+    public enum SolidWorksMessageBoxResult
+    {
+        /// <summary>
+        /// Abort was clicked
+        /// </summary>
+        Abort = 1,
+
+        /// <summary>
+        /// Ignore was clicked
+        /// </summary>
+        Ignore = 2,
+
+        /// <summary>
+        /// No was clicked
+        /// </summary>
+        No = 3,
+
+        /// <summary>
+        /// Ok was clicked
+        /// </summary>
+        Ok = 4,
+
+        /// <summary>
+        /// Retry was clicked
+        /// </summary>
+        Retry = 5,
+
+        /// <summary>
+        /// Yes was clicked
+        /// </summary>
+        Yes = 6,
+
+        /// <summary>
+        /// Cancel was clicked
+        /// </summary>
+        Cancel = 7
+    }
+}

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -574,10 +574,10 @@ namespace AngelSix.SolidDna
         /// Pops up a message box to the user with the given message
         /// </summary>
         /// <param name="message">The message to display to the user</param>
-        public void ShowMessageBox(string message, SolidWorksMessageBoxIcon icon = SolidWorksMessageBoxIcon.Information)
+        public SolidWorksMessageBoxResult ShowMessageBox(string message, SolidWorksMessageBoxIcon icon = SolidWorksMessageBoxIcon.Information, SolidWorksMessageBoxButtons buttons = SolidWorksMessageBoxButtons.Ok)
         {
             // Send message to user
-            mBaseObject.SendMsgToUser2(message, (int)icon, (int)SolidWorksMessageBoxButtons.Ok);
+            return (SolidWorksMessageBoxResult) mBaseObject.SendMsgToUser2(message, (int)icon, (int) buttons);
         }
 
         #endregion

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -569,15 +569,15 @@ namespace AngelSix.SolidDna
         #endregion
 
         #region User Interaction
-
+        
         /// <summary>
         /// Pops up a message box to the user with the given message
         /// </summary>
         /// <param name="message">The message to display to the user</param>
-        public void ShowMessageBox(string message, SolidWorksMessageBoxIcon icon = SolidWorksMessageBoxIcon.Information)
+        public SolidWorksMessageBoxResult ShowMessageBox(string message, SolidWorksMessageBoxIcon icon = SolidWorksMessageBoxIcon.Information, SolidWorksMessageBoxButtons buttons = SolidWorksMessageBoxButtons.Ok)
         {
             // Send message to user
-            mBaseObject.SendMsgToUser2(message, (int)icon, (int)SolidWorksMessageBoxButtons.Ok);
+            return (SolidWorksMessageBoxResult) mBaseObject.SendMsgToUser2(message, (int)icon, (int) buttons);
         }
 
         #endregion

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -574,10 +574,10 @@ namespace AngelSix.SolidDna
         /// Pops up a message box to the user with the given message
         /// </summary>
         /// <param name="message">The message to display to the user</param>
-        public SolidWorksMessageBoxResult ShowMessageBox(string message, SolidWorksMessageBoxIcon icon = SolidWorksMessageBoxIcon.Information, SolidWorksMessageBoxButtons buttons = SolidWorksMessageBoxButtons.Ok)
+        public void ShowMessageBox(string message, SolidWorksMessageBoxIcon icon = SolidWorksMessageBoxIcon.Information)
         {
             // Send message to user
-            return (SolidWorksMessageBoxResult) mBaseObject.SendMsgToUser2(message, (int)icon, (int) buttons);
+            mBaseObject.SendMsgToUser2(message, (int)icon, (int)SolidWorksMessageBoxButtons.Ok);
         }
 
         #endregion

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
@@ -364,7 +364,7 @@ namespace AngelSix.SolidDna
                 // The list of icons
                 mBaseObject.MainIconList = icons.ToArray();
 
-                // Use the largest available image for small icons too
+                // Smallest icon for this one
                 mBaseObject.SmallIconList = icons.First();
             }
 

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
@@ -365,7 +365,7 @@ namespace AngelSix.SolidDna
                 mBaseObject.MainIconList = icons.ToArray();
 
                 // Use the largest available image for small icons too
-                mBaseObject.SmallIconList = icons.Last();
+                mBaseObject.SmallIconList = icons.First();
             }
 
             #endregion


### PR DESCRIPTION
Redoing this request since I didn't include everything for it to make sense.

I fixed the SmallIconList error that was grabbing the largest icon, instead of smallest icon.

Message box now allows you to specify the type of buttons and get the result
See
http://help.solidworks.com/2018/english/api/sldworksapi/solidworks.interop.sldworks~solidworks.interop.sldworks.isldworks~sendmsgtouser2.html