### PR TITLE
Reload active model info when active model is saved

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -377,6 +377,9 @@ namespace AngelSix.SolidDna
         /// </summary>
         private void ActiveModel_Saved()
         {
+            // Reload active model info (filepath may have changed)
+            ReloadActiveModelInformation();
+        
             // Inform listeners
             ActiveFileSaved(mActiveModel?.FilePath, mActiveModel);
         }


### PR DESCRIPTION
Without this, certain info about the Model can be out of date. (i.e. FilePath)