### PR TITLE
Tiny refactorings

### DIFF
--- a/SolidDna/AngelSix.SolidDna/Exception/ExceptionHelpers.cs
+++ b/SolidDna/AngelSix.SolidDna/Exception/ExceptionHelpers.cs
@@ -39,7 +39,7 @@ namespace AngelSix.SolidDna
 
             while (ex != null)
             {
-                text = ex.ToString() + System.Environment.NewLine + text;
+                text = ex + Environment.NewLine + text;
 
                 ex = ex.InnerException;
             }

--- a/SolidDna/AngelSix.SolidDna/Localization/Implementation/FormatProviders/BaseFormatProvider.cs
+++ b/SolidDna/AngelSix.SolidDna/Localization/Implementation/FormatProviders/BaseFormatProvider.cs
@@ -33,7 +33,7 @@ namespace AngelSix.SolidDna
         #region Protected Helpers
 
         /// <summary>
-        /// Gets the file data for the specified resource, storing a cached version if specified
+        /// Gets the file data for the specified resource, storing a cached version if specified.
         /// IMPORTANT:
         /// NOTE: Make sure any and all await calls inside this function and its children
         ///       use ConfigureAwait(false). This is because the parent has to support 

--- a/SolidDna/AngelSix.SolidDna/Localization/Implementation/FormatProviders/BaseFormatProvider.cs
+++ b/SolidDna/AngelSix.SolidDna/Localization/Implementation/FormatProviders/BaseFormatProvider.cs
@@ -16,7 +16,7 @@ namespace AngelSix.SolidDna
         /// <summary>
         /// A lock to limit access to the processes to one at a time
         /// </summary>
-        private SemaphoreSlim mSelfLock = new SemaphoreSlim(1, 1);
+        private readonly SemaphoreSlim mSelfLock = new SemaphoreSlim(1, 1);
 
         /// <summary>
         /// A list of all cached resources

--- a/SolidDna/AngelSix.SolidDna/Localization/Implementation/FormatProviders/XmlFormatProvider.cs
+++ b/SolidDna/AngelSix.SolidDna/Localization/Implementation/FormatProviders/XmlFormatProvider.cs
@@ -46,14 +46,14 @@ namespace AngelSix.SolidDna
         public async Task<bool> GetStringAsync(ResourceDefinition resource, string name, string culture, Action<string> onResult)
         {
             // Get string document for this culture
-            var document = await GetResourceDocumentAsync(resource, (stream) => { return XDocument.Load(stream); }, culture).ConfigureAwait(false);
+            var document = await GetResourceDocumentAsync(resource, XDocument.Load, culture).ConfigureAwait(false);
 
             // If it is null, try and find the default culture if specified
             if (document == null)
             {
                 if (resource.UseDefaultCultureIfNotFound)
 
-                    document = await GetResourceDocumentAsync<XDocument>(resource, (stream) => { return XDocument.Load(stream); }).ConfigureAwait(false);
+                    document = await GetResourceDocumentAsync(resource, XDocument.Load).ConfigureAwait(false);
 
                 // Document not found so return false
                 if (document == null)
@@ -65,7 +65,9 @@ namespace AngelSix.SolidDna
                 return false;
 
             // Get the first element that matches the given name (ignore case)
-            var element = document.Root.Elements().FirstOrDefault(f => f.Attributes().Any(a => a.Name.LocalName == "Name") && string.Equals(name, f.Attributes().First(a => a.Name.LocalName == "Name").Value, StringComparison.CurrentCultureIgnoreCase));
+            var element = document.Root.Elements().FirstOrDefault(
+                f => f.Attributes().Any(a => a.Name.LocalName == "Name") && 
+                string.Equals(name, f.Attributes().First(a => a.Name.LocalName == "Name").Value, StringComparison.CurrentCultureIgnoreCase));
 
             // Return false if not found
             if (element == null)

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -154,12 +154,12 @@ namespace AngelSix.SolidDna
             return SolidDnaErrors.Wrap(() =>
             {
                 // Get version string (such as 23.2.0 for 2015 SP2.0)
-                string revisionNumber = mBaseObject.RevisionNumber();
+                var revisionNumber = mBaseObject.RevisionNumber();
 
                 // Get revision string (such as sw2015_SP20)
                 // Get build number (such as d150130.002)
                 // Get the hot fix string
-                mBaseObject.GetBuildNumbers2(out string revisionString, out string buildNumber, out string hotfixString);
+                mBaseObject.GetBuildNumbers2(out var revisionString, out var buildNumber, out var hotfixString);
 
                 return new SolidWorksVersion(revisionNumber, revisionString, buildNumber, hotfixString);
             },

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -68,7 +68,7 @@ namespace AngelSix.SolidDna
         /// <summary>
         /// The command manager
         /// </summary>
-        public CommandManager CommandManager { get; private set; }
+        public CommandManager CommandManager { get; }
 
         /// <summary>
         /// True if the application is disposing

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -251,7 +251,7 @@ namespace AngelSix.SolidDna
                 if (mFileLoading != null)
                 {
                     // Check the active document
-                    using (var activeDoc = new Model((ModelDoc2)mBaseObject.ActiveDoc))
+                    using (var activeDoc = new Model(mBaseObject.IActiveDoc2))
                     {
                         // If this is the same file that is currently being loaded, ignore this event
                         if (activeDoc != null && string.Equals(mFileLoading, activeDoc.FilePath, StringComparison.OrdinalIgnoreCase))

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -154,20 +154,14 @@ namespace AngelSix.SolidDna
             return SolidDnaErrors.Wrap(() =>
             {
                 // Get version string (such as 23.2.0 for 2015 SP2.0)
-                var revisionNumber = mBaseObject.RevisionNumber();
+                string revisionNumber = mBaseObject.RevisionNumber();
 
                 // Get revision string (such as sw2015_SP20)
                 // Get build number (such as d150130.002)
                 // Get the hot fix string
-                mBaseObject.GetBuildNumbers2(out var revisionString, out var buildNumber, out var hotfixString);
+                mBaseObject.GetBuildNumbers2(out string revisionString, out string buildNumber, out string hotfixString);
 
-                return new SolidWorksVersion
-                {
-                    RevisionNumber = revisionNumber,
-                    Revision = revisionString,
-                    BuildNumber = buildNumber,
-                    Hotfix = hotfixString
-                };
+                return new SolidWorksVersion(revisionNumber, revisionString, buildNumber, hotfixString);
             },
                 SolidDnaErrorTypeCode.SolidWorksApplication,
                 SolidDnaErrorCode.SolidWorksApplicationVersionError,

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -463,7 +463,7 @@ namespace AngelSix.SolidDna
         /// </summary>
         /// <param name="database">The database to read</param>
         /// <param name="list">The list to add materials to</param>
-        private void ReadMaterials(string database, ref List<Material> list)
+        private static void ReadMaterials(string database, ref List<Material> list)
         {
             // First make sure the file exists
             if (!File.Exists(database))

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksVersion.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksVersion.cs
@@ -75,13 +75,13 @@
             // So far from all previous versions it is safe to assume that
             // the year (SolidWorks 20XX) of the product is the revision number
             // - 8 + 2000 so revision 23 is 2015
-            Version = int.TryParse(revisionParts[0], out int version) ? version - 8 + 2000 : versionUnknown;
+            Version = int.TryParse(revisionParts[0], out var version) ? version - 8 + 2000 : versionUnknown;
 
             // Extract the first part of the revision number for the service pack
-            ServicePackMajor = revisionParts.Length >= 2 && int.TryParse(revisionParts[1], out int major) ? major : versionUnknown;
+            ServicePackMajor = revisionParts.Length >= 2 && int.TryParse(revisionParts[1], out var major) ? major : versionUnknown;
 
             // Extract the second part of the revision number for the service pack
-            ServicePackMinor = revisionParts.Length >= 3 && int.TryParse(revisionParts[2], out int minor) ? minor : versionUnknown;
+            ServicePackMinor = revisionParts.Length >= 3 && int.TryParse(revisionParts[2], out var minor) ? minor : versionUnknown;
         }
 
         #endregion

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksVersion.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksVersion.cs
@@ -5,77 +5,85 @@
     /// </summary>
     public class SolidWorksVersion
     {
-        /// <summary>
-        /// The version, such as 2017
-        /// If unknown will return -1
-        /// </summary>
-        public int Version
-        {
-            get
-            {
-                // So far from all previous versions it is safe to assume that
-                // the year (SolidWorks 20XX) of the product is the revision number
-                // - 8 + 2000 so revision 23 is 2015
-                int result;
-                if (string.IsNullOrEmpty(RevisionNumber) || !RevisionNumber.Contains(".") || !int.TryParse(RevisionNumber.Split('.')[0], out result))
-                    return -1;
-
-                return result - 8 + 2000;
-            }
-        }
+        #region Public properties
 
         /// <summary>
-        /// The major service pack number, such as 2 for SP2.0
+        /// The version, such as 2017.
         /// If unknown will return -1
         /// </summary>
-        public int ServicePackMajor
-        {
-            get
-            {
-                // Extract the second part of the revision number for the service pack
-                int result;
-                if (string.IsNullOrEmpty(RevisionNumber) || !RevisionNumber.Contains(".") || RevisionNumber.Split('.').Length < 2 || !int.TryParse(RevisionNumber.Split('.')[1], out result))
-                    return -1;
-
-                return result;
-            }
-        }
+        public int Version { get; }
 
         /// <summary>
-        /// The minor service pack number, such as 0 for SP2.0
+        /// The major service pack number, such as 2 for SP2.0.
         /// If unknown will return -1
         /// </summary>
-        public int ServicePackMinor
-        {
-            get
-            {
-                // Extract the second part of the revision number for the service pack
-                int result;
-                if (string.IsNullOrEmpty(RevisionNumber) || !RevisionNumber.Contains(".") || RevisionNumber.Split('.').Length < 3 || !int.TryParse(RevisionNumber.Split('.')[2], out result))
-                    return -1;
+        public int ServicePackMajor { get; }
 
-                return result;
-            }
-        }
+        /// <summary>
+        /// The minor service pack number, such as 0 for SP2.0.
+        /// If unknown will return -1
+        /// </summary>
+        public int ServicePackMinor { get; }
 
         /// <summary>
         /// The raw revision, for example where SolidWorks 2015 SP2.0 is 23.2.0
         /// </summary>
-        public string RevisionNumber { get; set; }
+        public string RevisionNumber { get; }
 
         /// <summary>
         /// The raw revision, for example where SolidWorks 2015 SP2.0 is 23.2.0
         /// </summary>
-        public string Revision { get; set; }
+        public string Revision { get; }
 
         /// <summary>
         /// The raw build number, for example where SolidWorks 2015 SP2.0 it is d150130.002
         /// </summary>
-        public string BuildNumber { get; set; }
+        public string BuildNumber { get; }
 
         /// <summary>
         /// The raw hotfix string
         /// </summary>
-        public string Hotfix { get; set; }
+        public string Hotfix { get; }
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// SolidWorks version information
+        /// </summary>
+        /// <param name="revisionNumber"></param>
+        /// <param name="revision"></param>
+        /// <param name="buildNumber"></param>
+        /// <param name="hotfix"></param>
+        public SolidWorksVersion(string revisionNumber, string revision, string buildNumber, string hotfix)
+        {
+            RevisionNumber = revisionNumber;
+            Revision = revision;
+            BuildNumber = buildNumber;
+            Hotfix = hotfix;
+
+            const int versionUnknown = -1;
+            if (string.IsNullOrEmpty(revisionNumber) || !revisionNumber.Contains("."))
+            {
+                Version = ServicePackMajor = ServicePackMinor = versionUnknown;
+                return;
+            }
+
+            var revisionParts = revisionNumber.Split('.');
+
+            // So far from all previous versions it is safe to assume that
+            // the year (SolidWorks 20XX) of the product is the revision number
+            // - 8 + 2000 so revision 23 is 2015
+            Version = int.TryParse(revisionParts[0], out int version) ? version - 8 + 2000 : versionUnknown;
+
+            // Extract the first part of the revision number for the service pack
+            ServicePackMajor = revisionParts.Length >= 2 && int.TryParse(revisionParts[1], out int major) ? major : versionUnknown;
+
+            // Extract the second part of the revision number for the service pack
+            ServicePackMinor = revisionParts.Length >= 3 && int.TryParse(revisionParts[2], out int minor) ? minor : versionUnknown;
+        }
+
+        #endregion
     }
 }

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/CommandManager.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/CommandManager.cs
@@ -41,7 +41,7 @@ namespace AngelSix.SolidDna
         /// <param name="tooltip">Tool tip for the CommandGroup</param>
         /// <param name="hint">Text displayed in SOLIDWORKS status bar when a user's mouse pointer is over the CommandGroup</param>
         /// <param name="position">Position of the CommandGroup in the CommandManager for all document templates.
-        /// NOTE: Specify 0 to add the CommandGroup to the beginning of the CommandMananger, or specify -1 to add it to the end of the CommandManager.
+        /// NOTE: Specify 0 to add the CommandGroup to the beginning of the CommandManager, or specify -1 to add it to the end of the CommandManager.
         /// NOTE: You can also use ICommandGroup::MenuPosition to control the position of the CommandGroup in specific document templates.</param>
         /// <param name="ignorePreviousVersion">True to remove all previously saved customization and toolbar information before creating a new CommandGroup, false to not.
         /// Call CommandManager.GetGroupDataFromRegistry before calling this method to determine how to set IgnorePreviousVersion. Set IgnorePreviousVersion to true to prevent SOLIDWORKS from saving the current toolbar setting to the registry, even if there is no previous version.</param>
@@ -85,7 +85,7 @@ namespace AngelSix.SolidDna
         /// <param name="tooltip">The tool tip</param>
         /// <param name="hint">The hint</param>
         /// <param name="position">Position of the CommandGroup in the CommandManager for all document templates.
-        /// NOTE: Specify 0 to add the CommandGroup to the beginning of the CommandMananger, or specify -1 to add it to the end of the CommandManager.
+        /// NOTE: Specify 0 to add the CommandGroup to the beginning of the CommandManager, or specify -1 to add it to the end of the CommandManager.
         /// NOTE: You can also use ICommandGroup::MenuPosition to control the position of the CommandGroup in specific document templates.</param>
         /// <param name="ignorePreviousVersion">True to remove all previously saved customization and toolbar information before creating a new CommandGroup, false to not.
         ///     Call CommandManager.GetGroupDataFromRegistry before calling this method to determine how to set IgnorePreviousVersion.

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
@@ -235,7 +235,7 @@ namespace AngelSix.SolidDna
             if (!pathFormat.Contains("{0}"))
                 throw new SolidDnaException(SolidDnaErrors.CreateError(
                     SolidDnaErrorTypeCode.SolidWorksCommandManager,
-                    SolidDnaErrorCode.SolidWorksCommandGroupIvalidPathFormatError,
+                    SolidDnaErrorCode.SolidWorksCommandGroupInvalidPathFormatError,
                     Localization.GetString("ErrorSolidWorksCommandGroupIconListInvalidPathError")));
 
             // Find 20 image

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
@@ -29,7 +29,7 @@ namespace AngelSix.SolidDna
         /// <summary>
         /// The Id used when this command group was created
         /// </summary>
-        public int UserId { get; private set; }
+        public int UserId { get; }
 
         /// <summary>
         /// The title of this command group

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Tab/CommandManagerTab.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Tab/CommandManagerTab.cs
@@ -12,7 +12,7 @@ namespace AngelSix.SolidDna
         /// <summary>
         /// The command tab box for this tab
         /// </summary>
-        public CommandManagerTabBox Box { get; private set; }
+        public CommandManagerTabBox Box { get; }
 
         #endregion
 

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Integration/AddinIntegration.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Integration/AddinIntegration.cs
@@ -171,15 +171,14 @@ namespace AngelSix.SolidDna
         /// <summary>
         /// Called when SolidWorks has loaded our add-in and wants us to do our connection logic
         /// </summary>
-        /// <param name="ThisSW">The current SolidWorks instance</param>
-        /// <param name="Cookie">The current SolidWorks cookie Id</param>
+        /// <param name="thisSw">The current SolidWorks instance</param>
+        /// <param name="cookie">The current SolidWorks cookie Id</param>
         /// <returns></returns>
-        public bool ConnectToSW(object ThisSW, int Cookie)
+        public bool ConnectToSW(object thisSw, int cookie)
         {
             try
             {
-                // Get the path to this actual add-in dll
-                var assemblyFilePath = this.AssemblyFilePath();
+                // Get the directory path to this actual add-in dll
                 var assemblyPath = this.AssemblyPath();
 
                 // Log it
@@ -203,13 +202,13 @@ namespace AngelSix.SolidDna
                 Logger.LogDebugSource($"Setting AddinCallbackInfo...");
 
                 // Setup callback info
-                var ok = ((SldWorks)ThisSW).SetAddinCallbackInfo2(0, this, Cookie);
+                var ok = ((SldWorks)thisSw).SetAddinCallbackInfo2(0, this, cookie);
 
                 // Log it
                 Logger.LogDebugSource($"PlugInIntegration Setup...");
 
                 // Setup plug-in application domain
-                PlugInIntegration.Setup(assemblyPath, ((SldWorks)ThisSW).RevisionNumber(), Cookie);
+                PlugInIntegration.Setup(assemblyPath, ((SldWorks)thisSw).RevisionNumber(), cookie);
 
                 // Log it
                 Logger.LogDebugSource($"Firing PreLoadPlugIns...");

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Model.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Model.cs
@@ -576,7 +576,7 @@ namespace AngelSix.SolidDna
         /// <param name="featureAction">The callback action that is called for each feature in the model</param>
         /// <param name="startFeature">The feature to start at</param>
         /// <param name="featureDepth">The current depth of the sub-features based on the original calling feature</param>
-        private void RecurseFeatures(Action<ModelFeature, int> featureAction, Feature startFeature = null, int featureDepth = 0)
+        private static void RecurseFeatures(Action<ModelFeature, int> featureAction, Feature startFeature = null, int featureDepth = 0)
         {
             // Get the current feature
             var currentFeature = startFeature;


### PR DESCRIPTION
Multiple small improvements. 

Largest one is adding a constructor for SolidWorksVersion because it will never be used without a constructor anyway and all parameters are needed to properly set it up.