### PR TITLE
Added separator before command manager items

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
@@ -476,8 +476,40 @@ namespace AngelSix.SolidDna
 
             // If there are items to add...
             if (ids?.Count > 0)
+            {
                 // Add all the items
                 tab.Box.UnsafeObject.AddCommands(ids.ToArray(), styles.ToArray());
+
+                // Add a separator before each item that wants one.
+                AddSeparators(items, tab);
+            }
+        }
+
+        /// <summary>
+        /// Add a separator before each <see cref="CommandManagerItem"/> that needs one.
+        /// </summary>
+        /// <param name="items"></param>
+        /// <param name="tab"></param>
+        private static void AddSeparators(List<CommandManagerItem> items, CommandManagerTab tab)
+        {
+            // Get the current tab box
+            var tabBox = (CommandTabBox) tab.Box.UnsafeObject;
+
+            // Add a separator before each item that wants one
+            var itemsThatNeedSeparator = items.Where(f => f.AddSeparatorBeforeThisItem).ToList();
+            foreach (var item in itemsThatNeedSeparator)
+            {
+                // Add the separator and split the current tab box in two.
+                // Returns the newly created tab box that contains the current items and all items on the right of it.
+                var newTabBox = tab.UnsafeObject.AddSeparator(tabBox, item.CommandId);
+
+                // Stop if the don't receive a new tab box.
+                if (newTabBox == null)
+                    break;
+                
+                // Use the new tab box to create the next separator.
+                tabBox = newTabBox;
+            }
         }
 
         #endregion

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Item/CommandManagerItem.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Item/CommandManagerItem.cs
@@ -10,6 +10,11 @@ namespace AngelSix.SolidDna
         #region Public Properties
 
         /// <summary>
+        /// True to add a separator bar to the left of this item.
+        /// </summary>
+        public bool AddSeparatorBeforeThisItem { get; set; }
+
+        /// <summary>
         /// The unique Id of this item (set by the parent)
         /// </summary>
         public int UniqueId { get; set; }


### PR DESCRIPTION
Good job on hiding the mess of creating tabs, boxes and items, Luke. 

I added a property to the command manager item to set a flag that it needs a separator on its left. 

Each separator splits the tab box, so I use the new box to create the next separator. The current CommandManagerTab can only store one box, so we might have to turn that into a list.