### PR TITLE
Fix FileOpenPostNotify event for view only modes

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Application/SolidWorksApplication.cs
@@ -323,9 +323,16 @@ namespace AngelSix.SolidDna
                     // Check the active document
                     using (var activeDoc = new Model(BaseObject.IActiveDoc2))
                     {
-                        // If this is the same file that is currently being loaded, ignore this event
-                        if (string.Equals(mFileLoading, activeDoc.FilePath, StringComparison.OrdinalIgnoreCase))
-                            return;
+                        // View Only mode (Large Assembly Review and Quick View) does not fire the FileOpenPostNotify event, so we catch these models here.
+                        var loadingInViewOnlyMode = activeDoc.UnsafeObject.IsOpenedViewOnly();
+                        if (loadingInViewOnlyMode)
+                            FileOpenPostNotify(activeDoc.FilePath);
+                        else
+                        {
+                            // If this is the same file that is currently being loaded, ignore this event
+                            if (string.Equals(mFileLoading, activeDoc.FilePath, StringComparison.OrdinalIgnoreCase))
+                                return;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fire FileOpenPostNotify directly when a model is being loaded in View Only mode (large design review or quick view), because SolidWorks does not fire this event. 

Fixes #93 

There might be side effects, but I haven't seen any so far.