### PR TITLE
Add parameter for the document types when creating command groups 

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/CommandManager.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/CommandManager.cs
@@ -68,6 +68,7 @@ namespace AngelSix.SolidDna
         /// <param name="addDropdownBoxForParts">If true, adds a command box to the toolbar for parts that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
         /// <param name="addDropdownBoxForAssemblies">If true, adds a command box to the toolbar for assemblies that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
         /// <param name="addDropdownBoxForDrawings">If true, adds a command box to the toolbar for drawings that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
+        /// <param name="documentTypes">The document types where this menu/toolbar is visible.</param>
         /// <returns></returns>
         public CommandManagerGroup CreateCommandGroupAndTabs(
             string title, 
@@ -82,7 +83,8 @@ namespace AngelSix.SolidDna
             bool hasToolbar = true,
             bool addDropdownBoxForParts = false,
             bool addDropdownBoxForAssemblies = false,
-            bool addDropdownBoxForDrawings = false)
+            bool addDropdownBoxForDrawings = false,
+            ModelTemplateType documentTypes = ModelTemplateType.Part | ModelTemplateType.Assembly | ModelTemplateType.Drawing)
         {
             // Wrap any error creating the taskpane in a SolidDna exception
             return SolidDnaErrors.Wrap(() =>
@@ -103,7 +105,8 @@ namespace AngelSix.SolidDna
                         hasToolbar,
                         addDropdownBoxForParts,
                         addDropdownBoxForAssemblies,
-                        addDropdownBoxForDrawings);
+                        addDropdownBoxForDrawings,
+                        documentTypes);
 
                     // Track all flyouts
                     mCommandFlyouts = flyoutItems;
@@ -210,6 +213,7 @@ namespace AngelSix.SolidDna
         /// <param name="addDropdownBoxForParts">If true, adds a command box to the toolbar for parts that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
         /// <param name="addDropdownBoxForAssemblies">If true, adds a command box to the toolbar for assemblies that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
         /// <param name="addDropdownBoxForDrawings">If true, adds a command box to the toolbar for drawings that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
+        /// <param name="documentTypes">The document types where this menu/toolbar is visible.</param>
         /// <returns></returns>
         private CommandManagerGroup CreateCommandGroup(
             string title, 
@@ -223,7 +227,8 @@ namespace AngelSix.SolidDna
             bool hasToolbar = true,
             bool addDropdownBoxForParts = false,
             bool addDropdownBoxForAssemblies = false,
-            bool addDropdownBoxForDrawings = false)
+            bool addDropdownBoxForDrawings = false, 
+            ModelTemplateType documentTypes = ModelTemplateType.Part | ModelTemplateType.Assembly | ModelTemplateType.Drawing)
         {
             // NOTE: We may need to look carefully at this Id if things get removed and re-added based on this SolidWorks note:
             //     
@@ -267,7 +272,8 @@ namespace AngelSix.SolidDna
                 hasToolbar,
                 addDropdownBoxForParts,
                 addDropdownBoxForAssemblies,
-                addDropdownBoxForDrawings);
+                addDropdownBoxForDrawings,
+                documentTypes);
 
             // Return it
             return group;

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/CommandManager/Group/CommandManagerGroup.cs
@@ -141,6 +141,7 @@ namespace AngelSix.SolidDna
         /// <param name="addDropdownBoxForParts">If true, adds a command box to the toolbar for parts that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
         /// <param name="addDropdownBoxForAssemblies">If true, adds a command box to the toolbar for assemblies that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
         /// <param name="addDropdownBoxForDrawings">If true, adds a command box to the toolbar for drawings that has a dropdown of all commands that are part of this group. The tooltip of the command group is used as the name.</param>
+        /// <param name="documentTypes">The document types where this menu/toolbar is visible</param>
         public CommandManagerGroup(
             ICommandGroup commandGroup, 
             List<CommandManagerItem> items, 
@@ -153,7 +154,8 @@ namespace AngelSix.SolidDna
             bool hasToolbar,
             bool addDropdownBoxForParts = false,
             bool addDropdownBoxForAssemblies = false,
-            bool addDropdownBoxForDrawings = false) : base(commandGroup)
+            bool addDropdownBoxForDrawings = false, 
+            ModelTemplateType documentTypes = ModelTemplateType.Part | ModelTemplateType.Assembly | ModelTemplateType.Drawing) : base(commandGroup)
         {
             // Store user Id, used to remove the command group
             UserId = userId;
@@ -175,8 +177,8 @@ namespace AngelSix.SolidDna
 
             // Set defaults
 
-            // Show for all types
-            MenuVisibleInDocumentTypes = ModelTemplateType.Assembly | ModelTemplateType.Part | ModelTemplateType.Drawing;
+            // Show for certain types of documents, or when no document is active.
+            MenuVisibleInDocumentTypes = documentTypes;
 
             // Have a menu
             HasMenu = hasMenu;


### PR DESCRIPTION
I found it really confusing why my add-in Tools menu wasn't visible when no model is open. Now it can be. We could still add 'None' to the defaults.

Changing the property after the group is activated does not work, so I added another parameter.