### PR TITLE
Addin installer improvements

### DIFF
--- a/Tools/Addin Installer/AngelSix.SolidWorksApi.AddinInstaller.csproj
+++ b/Tools/Addin Installer/AngelSix.SolidWorksApi.AddinInstaller.csproj
@@ -95,6 +95,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PathToFileNameConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Tools/Addin Installer/MainWindow.xaml
+++ b/Tools/Addin Installer/MainWindow.xaml
@@ -12,9 +12,7 @@
         MinWidth="525"
         Icon="Resources/favicon.ico">
     <Border Padding="10">
-
         <Grid>
-
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -34,7 +32,6 @@
 
                     <TextBox Padding="5" Name="RegAsmPath" />
                     <Button Name="BrowseRegAsmButton" Click="BrowseRegAsmButton_Click" Grid.Column="1" Content="Browse" Padding="5" />
-
                 </Grid>
 
                 <Label Content="Add-in Dll" FontWeight="Bold" />
@@ -46,12 +43,10 @@
 
                     <TextBox Padding="5" Name="DllPath" />
                     <Button Name="BrowseDllButton" Click="BrowseDllButton_Click" Grid.Column="1" Content="Browse" Padding="5" />
-
                 </Grid>
             </StackPanel>
 
             <Grid Grid.Row="2" Margin="0 20 0 0">
-
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
@@ -59,9 +54,7 @@
                 
                 <Button Name="UninstallButton" Content="Uninstall" Click="UninstallButton_Click" />
                 <Button Grid.Column="1" Margin="5 0 0 0" Name="InstallButton" Content="Install" Click="InstallButton_Click" />
-
             </Grid>
-
         </Grid>
     </Border>
 </Window>

--- a/Tools/Addin Installer/MainWindow.xaml
+++ b/Tools/Addin Installer/MainWindow.xaml
@@ -6,19 +6,23 @@
         xmlns:local="clr-namespace:AngelSix.SolidWorksApi.AddinInstaller"
         mc:Ignorable="d"
         Title="SolidWorks Addin Installer - angelsix.com" 
-        Height="350" 
+        Height="500" 
         MinHeight="350"
         Width="525" 
         MinWidth="525"
         Icon="Resources/favicon.ico">
+    <Window.Resources>
+        <local:PathToFileNameConverter x:Key="PathToFileNameConverter" />
+    </Window.Resources>
     <Border Padding="10">
         <Grid>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            
+
             <StackPanel>
                 <Label Content="SolidWorks Add-in Installer" FontWeight="Bold" FontSize="20" />
                 <TextBlock Margin="0 10" TextWrapping="WrapWithOverflow" Text="This tool will register and install a SolidWorks Add-in dll file into the SolidWorks registry so the add-in will show up in SolidWorks" />
@@ -30,7 +34,7 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
-                    <TextBox Padding="5" Name="RegAsmPath" />
+                    <TextBox Padding="5" Name="RegAsmPath" Margin="0 0 10 0" />
                     <Button Name="BrowseRegAsmButton" Click="BrowseRegAsmButton_Click" Grid.Column="1" Content="Browse" Padding="5" />
                 </Grid>
 
@@ -41,20 +45,46 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
 
-                    <TextBox Padding="5" Name="DllPath" />
+                    <TextBox Padding="5" Name="DllPath" Margin="0 0 10 0" />
                     <Button Name="BrowseDllButton" Click="BrowseDllButton_Click" Grid.Column="1" Content="Browse" Padding="5" />
                 </Grid>
             </StackPanel>
 
-            <Grid Grid.Row="2" Margin="0 20 0 0">
+            <Grid Grid.Row="1" Margin="0 20 0 0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                
-                <Button Name="UninstallButton" Content="Uninstall" Click="UninstallButton_Click" />
-                <Button Grid.Column="1" Margin="5 0 0 0" Name="InstallButton" Content="Install" Click="InstallButton_Click" />
+
+                <Button Name="UninstallButton" Content="Uninstall" 
+                        Padding="5"
+                        Click="UninstallButton_Click" Margin="0 0 5 0" />
+                <Button Grid.Column="1" Margin="5 0 0 0" Padding="5"
+                        Name="InstallButton" Content="Install" 
+                        Click="InstallButton_Click" />
             </Grid>
+
+            <Label Grid.Row="2" Content="Previous add-in Dlls" FontWeight="Bold" Margin="0 10 0 0" />
+            <ItemsControl Grid.Row="3" ItemsSource="{Binding PreviousAddInPaths}"
+                          HorizontalContentAlignment="Stretch" 
+                          ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate><!--DataType="system:String">-->
+                        <Grid HorizontalAlignment="Stretch">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Text="{Binding Converter={StaticResource PathToFileNameConverter}}" ToolTip="{Binding}" VerticalAlignment="Center" />
+                            <Button Grid.Column="1" Content="Install" Margin="5 2" Padding="5 2" Click="InstallPreviousAddIn_OnClick" />
+                            <Button Grid.Column="2" Content="Uninstall" Margin="5 2" Padding="5 2" Click="UninstallPreviousAddIn_OnClick" />
+                            <Button Grid.Column="3" Content="Remove" Margin="5 2 0 2" Padding="5 2" Click="RemovePathFromPrevious_OnClick" />
+                        </Grid>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </Grid>
     </Border>
 </Window>

--- a/Tools/Addin Installer/MainWindow.xaml.cs
+++ b/Tools/Addin Installer/MainWindow.xaml.cs
@@ -97,16 +97,26 @@ namespace AngelSix.SolidWorksApi.AddinInstaller
         private static bool SanityCheck(string regasmPath, string dllPath)
         {
             // Check RegAsm
-            if (string.IsNullOrEmpty(regasmPath) || !File.Exists(regasmPath))
+            if (string.IsNullOrEmpty(regasmPath))
             {
                 MessageBox.Show("Please specify a path to a valid RegAsm application", "No RegAsm found");
+                return false;
+            } 
+            if (!File.Exists(regasmPath))
+            {
+                MessageBox.Show("The RegAsm file does not exist", "No RegAsm found");
                 return false;
             }
 
             // Check Dll
-            if (string.IsNullOrEmpty(dllPath) || !File.Exists(dllPath))
+            if (string.IsNullOrEmpty(dllPath))
             {
                 MessageBox.Show("Please specify a path to a valid SolidWorks Add-in dll", "No Add-in found");
+                return false;
+            }
+            if (!File.Exists(dllPath))
+            {
+                MessageBox.Show("The dll file does not exist", "File not found");
                 return false;
             }
 

--- a/Tools/Addin Installer/MainWindow.xaml.cs
+++ b/Tools/Addin Installer/MainWindow.xaml.cs
@@ -21,12 +21,12 @@ namespace AngelSix.SolidWorksApi.AddinInstaller
         /// <summary>
         /// The name of the RegAsm tool
         /// </summary>
-        private string mRegAsmFilename = "RegAsm.exe";
+        private const string MRegAsmFilename = "RegAsm.exe";
 
         /// <summary>
         /// The folder location where 64bit .Net Frameworks are installed, relative to the Windows folder
         /// </summary>
-        private string mRegAsmWindowsPath = "Microsoft.NET\\Framework64";
+        private const string MRegAsmWindowsPath = "Microsoft.NET\\Framework64";
 
         #endregion
 
@@ -77,7 +77,7 @@ namespace AngelSix.SolidWorksApi.AddinInstaller
         {
             // Locate SolidWorks exe in Program Files
             var results = new List<string>();
-            FindByFilename(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), mRegAsmWindowsPath), null, mRegAsmFilename, results);
+            FindByFilename(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Windows), MRegAsmWindowsPath), null, MRegAsmFilename, results);
 
             // If we have at least one, use the last one (so newest version)
             if (results?.Count > 0)
@@ -93,7 +93,7 @@ namespace AngelSix.SolidWorksApi.AddinInstaller
         /// <param name="filename">The filename to find (case insensitive)</param>
         /// <param name="results">The results to store the results in</param>
         /// <returns></returns>
-        private void FindByFilename(string path, string pathContains, string filename, List<string> results = null)
+        private static void FindByFilename(string path, string pathContains, string filename, List<string> results = null)
         {
             // Create new list if none passed in
             if (results == null)
@@ -103,7 +103,7 @@ namespace AngelSix.SolidWorksApi.AddinInstaller
             try
             {
                 var files = Directory.EnumerateFiles(path).Where(f => string.Equals(Path.GetFileName(f), filename, StringComparison.InvariantCultureIgnoreCase)).ToList();
-                if (files?.Count > 0)
+                if (files.Count > 0)
                     results.AddRange(files);
             }
             catch
@@ -113,8 +113,7 @@ namespace AngelSix.SolidWorksApi.AddinInstaller
             try
             {
                 // Allow case-insensitive checking
-                if (pathContains != null)
-                    pathContains = pathContains.ToLower();
+                pathContains = pathContains?.ToLower();
 
                 // Search into directories that match
                 Directory.EnumerateDirectories(path).Where(f => string.IsNullOrEmpty(pathContains) || f.ToLower().Contains(pathContains)).ToList().ForEach(dir => FindByFilename(dir, null, filename, results));
@@ -135,7 +134,7 @@ namespace AngelSix.SolidWorksApi.AddinInstaller
         {
             var ofd = new OpenFileDialog
             {
-                Filter = $"RegAsm | {mRegAsmFilename}",
+                Filter = $"RegAsm | {MRegAsmFilename}",
                 InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Windows)
             };
 

--- a/Tools/Addin Installer/PathToFileNameConverter.cs
+++ b/Tools/Addin Installer/PathToFileNameConverter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Windows.Data;
+
+namespace AngelSix.SolidWorksApi.AddinInstaller
+{
+    public class PathToFileNameConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+            value != null && value is string path 
+                ? Path.GetFileName(path) 
+                : null;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/Tools/Addin Installer/Properties/Settings.Designer.cs
+++ b/Tools/Addin Installer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AngelSix.SolidWorksApi.AddinInstaller.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -20,6 +20,17 @@ namespace AngelSix.SolidWorksApi.AddinInstaller.Properties {
         public static Settings Default {
             get {
                 return defaultInstance;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        public global::System.Collections.Specialized.StringCollection PreviousPaths {
+            get {
+                return ((global::System.Collections.Specialized.StringCollection)(this["PreviousPaths"]));
+            }
+            set {
+                this["PreviousPaths"] = value;
             }
         }
     }

--- a/Tools/Addin Installer/Properties/Settings.settings
+++ b/Tools/Addin Installer/Properties/Settings.settings
@@ -1,7 +1,9 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="uri:settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="AngelSix.SolidWorksApi.AddinInstaller.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="PreviousPaths" Type="System.Collections.Specialized.StringCollection" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
+  </Settings>
 </SettingsFile>


### PR DESCRIPTION
I have been using the add-in installer for a bunch of projects, so I was looking for a way to spend less time browsing for files. I added a list of previously used DLL paths and buttons to install or uninstall it directly.

It stores the paths in the user's settings after installing or uninstalling is successful. You only see the filename in the UI, the whole path is in the tooltip.

![addin installer previous dlls](https://user-images.githubusercontent.com/15387410/87224847-02046600-c389-11ea-8d00-93038cdd874c.png)