### PR TITLE
Added useful properties to Component

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Component/Component.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Component/Component.cs
@@ -1,4 +1,5 @@
 ﻿using SolidWorks.Interop.sldworks;
+using SolidWorks.Interop.swconst;
 
 namespace AngelSix.SolidDna
 {
@@ -15,19 +16,75 @@ namespace AngelSix.SolidDna
         public Model AsModel => new Model (BaseObject.GetModelDoc2() as ModelDoc2);
 
         /// <summary>
-        /// Check if the Component is Root
-        /// </summary>
-        public bool IsRoot => BaseObject.IsRoot();
-
-        /// <summary>
         /// Get children from this Component
         /// </summary>
         public object[] Children => BaseObject.GetChildren() as object[];
 
         /// <summary>
-        /// Get the name of the component
+        /// Get the real name of the component, without the sub-assembly name and without instance numbers.
+        /// </summary>
+        public string CleanName
+        {
+            get
+            {
+                var nameWithInstanceNumber = Name;
+                var nameWithoutInstanceNumber = nameWithInstanceNumber.LastIndexOf('-') == -1
+                    ? nameWithInstanceNumber
+                    : nameWithInstanceNumber.Remove(nameWithInstanceNumber.LastIndexOf('-'));
+
+                return nameWithoutInstanceNumber.LastIndexOf('/') == -1
+                    ? nameWithoutInstanceNumber
+                    : nameWithoutInstanceNumber.Substring(nameWithoutInstanceNumber.LastIndexOf('/') + 1);
+            }
+        }
+
+        /// <summary>
+        /// The name of the configuration for this component.
+        /// </summary>
+        public string ConfigurationName => BaseObject.ReferencedConfiguration;
+
+        /// <summary>
+        /// The name of the display state for this component.
+        /// </summary>
+        public string DisplayStateName => BaseObject.ReferencedDisplayState2;
+
+        /// <summary>
+        /// The complete path to the component. Can be null.
+        /// </summary>
+        public string FilePath => BaseObject.GetPathName();
+
+        /// <summary>
+        /// Check if the Component is Root
+        /// </summary>
+        public bool IsRoot => BaseObject.IsRoot();
+
+        /// <summary>
+        /// Check if this is a top-level component or the root component by making sure it has no parent.
+        /// </summary>
+        public bool IsTopLevelComponent => Parent == null;
+
+        /// <summary>
+        /// Check if the component is a virtual component.
+        /// Virtual components are saved within the assembly, not to a separate file.
+        /// </summary>
+        public bool IsVirtual => BaseObject.IsVirtual;
+
+        /// <summary>
+        /// Check if this component is visible. Returns false when the visibility is unknown.
+        /// </summary>
+        public bool IsVisible => BaseObject.Visible == (int) swComponentVisibilityState_e.swComponentVisible;
+
+        /// <summary>
+        /// Get the name of the component. 
+        /// Includes the instance number and the sub-assembly name and instance number, for example subAssembly1-2/Part1-1.
         /// </summary>
         public string Name => BaseObject.Name2;
+
+        /// <summary>
+        /// Get the parent component for this component.
+        /// Is null for the root component and for top-level components.
+        /// </summary>
+        public Component Parent => BaseObject.GetParent() == null ? null : new Component(BaseObject.GetParent());
 
         #endregion
 

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Component/Component.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Component/Component.cs
@@ -41,12 +41,20 @@ namespace AngelSix.SolidDna
         /// <summary>
         /// The name of the configuration for this component.
         /// </summary>
-        public string ConfigurationName => BaseObject.ReferencedConfiguration;
+        public string ConfigurationName
+        {
+            get => BaseObject.ReferencedConfiguration;
+            set => BaseObject.ReferencedConfiguration = value;
+        } 
 
         /// <summary>
         /// The name of the display state for this component.
         /// </summary>
-        public string DisplayStateName => BaseObject.ReferencedDisplayState2;
+        public string DisplayStateName
+        {
+            get => BaseObject.ReferencedDisplayState2;
+            set => BaseObject.ReferencedDisplayState2 = value;
+        }
 
         /// <summary>
         /// The complete path to the component. Can be null.
@@ -72,7 +80,13 @@ namespace AngelSix.SolidDna
         /// <summary>
         /// Check if this component is visible. Returns false when the visibility is unknown.
         /// </summary>
-        public bool IsVisible => BaseObject.Visible == (int) swComponentVisibilityState_e.swComponentVisible;
+        public bool IsVisible
+        {
+            get => BaseObject.Visible == (int)swComponentVisibilityState_e.swComponentVisible;
+            set => BaseObject.Visible = (int)(value
+                ? swComponentVisibilityState_e.swComponentVisible
+                : swComponentVisibilityState_e.swComponentHidden);
+        }
 
         /// <summary>
         /// Get the name of the component. 

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Component/Component.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Component/Component.cs
@@ -62,6 +62,11 @@ namespace AngelSix.SolidDna
         public string FilePath => BaseObject.GetPathName();
 
         /// <summary>
+        /// Check if this sub-assembly is flexible.
+        /// </summary>
+        public bool IsFlexible => BaseObject.Solving == (int)swComponentSolvingOption_e.swComponentFlexibleSolving;
+
+        /// <summary>
         /// Check if the Component is Root
         /// </summary>
         public bool IsRoot => BaseObject.IsRoot();


### PR DESCRIPTION
I added a bunch of component properties that I frequently use or that are annoying in the SW API.

I'd love to return a list of Components as children, instead of a nullable object array. What's your position on that?