### PR TITLE
Fixed attaching events after the model data is reloaded

### DIFF
--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Model.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Model.cs
@@ -165,9 +165,6 @@ namespace AngelSix.SolidDna
         {
             // Update information about this model
             ReloadModelData();
-
-            // Attach event handlers
-            SetupModelEventHandlers();
         }
 
         #endregion
@@ -179,12 +176,15 @@ namespace AngelSix.SolidDna
         /// </summary>
         protected void ReloadModelData()
         {
-            // Clean up any previous data
+            // Clean up any previous data and unhook event handlers
             DisposeAllReferences();
 
             // Can't do much if there is no document
             if (BaseObject == null)
                 return;
+
+            // Attach event handlers
+            SetupModelEventHandlers();
 
             // Get the file path
             FilePath = BaseObject.GetPathName();

--- a/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Model.cs
+++ b/SolidDna/AngelSix.SolidDna/SolidWorks/Models/Model.cs
@@ -183,9 +183,6 @@ namespace AngelSix.SolidDna
             if (BaseObject == null)
                 return;
 
-            // Attach event handlers
-            SetupModelEventHandlers();
-
             // Get the file path
             FilePath = BaseObject.GetPathName();
 
@@ -209,6 +206,9 @@ namespace AngelSix.SolidDna
 
             // Set assembly access
             Assembly = IsAssembly ? new AssemblyDocument((AssemblyDoc)BaseObject) : null;
+
+            // Attach event handlers
+            SetupModelEventHandlers();
 
             // Inform listeners
             ModelInformationChanged();


### PR DESCRIPTION
There are currently four method calls to Model.ReloadModelData, for example after a save or save as. ReloadModelData unhooks all events in DisposeAllReferences, but these handlers are not attached again. 

This PR fixes that by moving setting up the event handlers within ReloadModelData, so we can never forget it.